### PR TITLE
Fixed missing prop error

### DIFF
--- a/lib/KendoWidgetMixin.js
+++ b/lib/KendoWidgetMixin.js
@@ -114,7 +114,7 @@ var KendoWidgetMixin = function (widget) {
      * Default Kendo widget renderer
      */
     render: function () {
-      var other = _.omit(this.props, [ 'options', 'children', 'tag' ]);
+      var other = _.omit(this.props, [ 'options', 'children', 'tag', 'debug', 'reactive' ]);
       return React.DOM[this.props.tag](other, this.props.children);
     }
   };


### PR DESCRIPTION
This fixes the error that react generates, as div's don't have a debug or reactive prop.
